### PR TITLE
3321 Global Factor refactor

### DIFF
--- a/api/rest/bulk/global_factor.go
+++ b/api/rest/bulk/global_factor.go
@@ -1,0 +1,40 @@
+package bulk
+
+import (
+	"net/http"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/m6yf/bcwork/core/bulk"
+	"github.com/m6yf/bcwork/utils"
+)
+
+type GlobalFactorUpdateResponse struct {
+	Status string `json:"status"`
+}
+
+// GlobalFactorBulkPostHandler Update and enable Bulk insert Global Factor Fees
+// @Description Update Global Factor Fees in bulk
+// @Tags Bulk
+// @Accept json
+// @Produce json
+// @Param options body []GlobalFactorRequest true "Global Factor update Options"
+// @Success 200 {object} GlobalFactorUpdateResponse
+// @Security ApiKeyAuth
+// @Router /bulk/global/factor [post]
+func GlobalFactorBulkPostHandler(c *fiber.Ctx) error {
+	var requests []bulk.GlobalFactorRequest
+	if err := c.BodyParser(&requests); err != nil {
+		return utils.ErrorResponse(c, http.StatusBadRequest, "error parsing request body for global factor bulk update", err)
+	}
+
+	chunks, err := bulk.MakeGlobalFactorsChunks(requests)
+	if err != nil {
+		return utils.ErrorResponse(c, http.StatusBadRequest, "failed to create chunks for global factor bulk update", err)
+	}
+
+	if err := bulk.ProcessGlobalFactorsChunks(c, chunks); err != nil {
+		return utils.ErrorResponse(c, http.StatusBadRequest, "failed to process global factor bulk update", err)
+	}
+
+	return utils.SuccessResponse(c, http.StatusOK, "global factor bulk update successfully processed")
+}

--- a/api/rest/bulk/global_factor_test.go
+++ b/api/rest/bulk/global_factor_test.go
@@ -1,0 +1,43 @@
+package bulk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/m6yf/bcwork/api/rest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobalFactorBulkPostHandler_InvalidJSON(t *testing.T) {
+	const url = "/global/factor/bulk"
+
+	app := fiber.New()
+	app.Post(url, GlobalFactorBulkPostHandler)
+
+	invalidJSON := `{"key": "consultant_fee", "publisher_id": "id", "value": 5`
+
+	req := httptest.NewRequest("POST", url, bytes.NewBufferString(invalidJSON))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	fmt.Print(string(body))
+
+	var response rest.Response
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+	fmt.Print(response.Status)
+	fmt.Print(response.Message)
+	require.Equal(t, "error", response.Status)
+	require.Contains(t, response.Message, "error parsing request body for global factor bulk update")
+}

--- a/api/rest/docs/docs.go
+++ b/api/rest/docs/docs.go
@@ -214,6 +214,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/bulk/global/factor": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Update Global Factor Fees in bulk",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Bulk"
+                ],
+                "parameters": [
+                    {
+                        "description": "Global Factor update Options",
+                        "name": "options",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/bulk.GlobalFactorRequest"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/bulk.GlobalFactorUpdateResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/confiant": {
             "post": {
                 "security": [
@@ -1381,6 +1422,28 @@ const docTemplate = `{
                 }
             }
         },
+        "bulk.GlobalFactorRequest": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "publisher_id": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number"
+                }
+            }
+        },
+        "bulk.GlobalFactorUpdateResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "core.Confiant": {
             "type": "object",
             "properties": {
@@ -1984,9 +2047,6 @@ const docTemplate = `{
                 "created_at": {
                     "type": "string"
                 },
-                "created_by_id": {
-                    "type": "string"
-                },
                 "key": {
                     "type": "string"
                 },
@@ -2004,12 +2064,6 @@ const docTemplate = `{
         "core.GlobalFactorFilter": {
             "type": "object",
             "properties": {
-                "created_by_id": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
                 "key": {
                     "type": "array",
                     "items": {
@@ -2032,13 +2086,7 @@ const docTemplate = `{
         },
         "core.GlobalFactorRequest": {
             "type": "object",
-            "required": [
-                "created_by_id"
-            ],
             "properties": {
-                "created_by_id": {
-                    "type": "string"
-                },
                 "key": {
                     "type": "string"
                 },

--- a/api/rest/docs/swagger.json
+++ b/api/rest/docs/swagger.json
@@ -203,6 +203,47 @@
                 }
             }
         },
+        "/bulk/global/factor": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Update Global Factor Fees in bulk",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Bulk"
+                ],
+                "parameters": [
+                    {
+                        "description": "Global Factor update Options",
+                        "name": "options",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/bulk.GlobalFactorRequest"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/bulk.GlobalFactorUpdateResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/confiant": {
             "post": {
                 "security": [
@@ -1370,6 +1411,28 @@
                 }
             }
         },
+        "bulk.GlobalFactorRequest": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "publisher_id": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number"
+                }
+            }
+        },
+        "bulk.GlobalFactorUpdateResponse": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
         "core.Confiant": {
             "type": "object",
             "properties": {
@@ -1973,9 +2036,6 @@
                 "created_at": {
                     "type": "string"
                 },
-                "created_by_id": {
-                    "type": "string"
-                },
                 "key": {
                     "type": "string"
                 },
@@ -1993,12 +2053,6 @@
         "core.GlobalFactorFilter": {
             "type": "object",
             "properties": {
-                "created_by_id": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
                 "key": {
                     "type": "array",
                     "items": {
@@ -2021,13 +2075,7 @@
         },
         "core.GlobalFactorRequest": {
             "type": "object",
-            "required": [
-                "created_by_id"
-            ],
             "properties": {
-                "created_by_id": {
-                    "type": "string"
-                },
                 "key": {
                     "type": "string"
                 },

--- a/api/rest/docs/swagger.yaml
+++ b/api/rest/docs/swagger.yaml
@@ -35,6 +35,20 @@ definitions:
       status:
         type: string
     type: object
+  bulk.GlobalFactorRequest:
+    properties:
+      key:
+        type: string
+      publisher_id:
+        type: string
+      value:
+        type: number
+    type: object
+  bulk.GlobalFactorUpdateResponse:
+    properties:
+      status:
+        type: string
+    type: object
   core.Confiant:
     properties:
       confiant_key:
@@ -429,8 +443,6 @@ definitions:
     properties:
       created_at:
         type: string
-      created_by_id:
-        type: string
       key:
         type: string
       publisher_id:
@@ -442,10 +454,6 @@ definitions:
     type: object
   core.GlobalFactorFilter:
     properties:
-      created_by_id:
-        items:
-          type: string
-        type: array
       key:
         items:
           type: string
@@ -461,16 +469,12 @@ definitions:
     type: object
   core.GlobalFactorRequest:
     properties:
-      created_by_id:
-        type: string
       key:
         type: string
       publisher_id:
         type: string
       value:
         type: number
-    required:
-    - created_by_id
     type: object
   core.Pixalate:
     properties:
@@ -971,6 +975,31 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/bulk.FloorUpdateResponse'
+      security:
+      - ApiKeyAuth: []
+      tags:
+      - Bulk
+  /bulk/global/factor:
+    post:
+      consumes:
+      - application/json
+      description: Update Global Factor Fees in bulk
+      parameters:
+      - description: Global Factor update Options
+        in: body
+        name: options
+        required: true
+        schema:
+          items:
+            $ref: '#/definitions/bulk.GlobalFactorRequest'
+          type: array
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/bulk.GlobalFactorUpdateResponse'
       security:
       - ApiKeyAuth: []
       tags:

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"net/http"
+	"strings"
+
 	swagger "github.com/arsmn/fiber-swagger/v2"
 	"github.com/gofiber/adaptor/v2"
 	"github.com/gofiber/fiber/v2"
@@ -23,8 +26,6 @@ import (
 	"github.com/supertokens/supertokens-golang/recipe/thirdpartyemailpassword"
 	"github.com/supertokens/supertokens-golang/recipe/thirdpartyemailpassword/tpepmodels"
 	"github.com/supertokens/supertokens-golang/supertokens"
-	"net/http"
-	"strings"
 
 	_ "github.com/m6yf/bcwork/api/rest/docs"
 	_ "github.com/m6yf/bcwork/validations"
@@ -244,6 +245,7 @@ func ApiCmd(cmd *cobra.Command, args []string) {
 	app.Post("/bulk/factor", validations.ValidateBulkFactors, bulk.FactorBulkPostHandler)
 	app.Post("/bulk/floor", validations.ValidateBulkFloor, bulk.FloorBulkPostHandler)
 	app.Post("/bulk/dpo", validations.ValidateDPOInBulk, bulk.DemandPartnerOptimizationBulkPostHandler)
+	app.Post("/bulk/global/factor", validations.ValidateBulkGlobalFactor, bulk.GlobalFactorBulkPostHandler)
 
 	app.Post("/config/get", rest.ConfigurationGetHandler)
 	app.Post("/config", validations.ValidateConfig, rest.ConfigurationPostHandler)

--- a/core/bulk/global_factor.go
+++ b/core/bulk/global_factor.go
@@ -1,0 +1,101 @@
+package bulk
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/m6yf/bcwork/bcdb"
+	"github.com/m6yf/bcwork/models"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
+	"github.com/volatiletech/null/v8"
+	"github.com/volatiletech/sqlboiler/v4/boil"
+)
+
+type GlobalFactorRequest struct {
+	Key       string  `json:"key" validate:"globalFactorKey"`
+	Publisher string  `json:"publisher_id" `
+	Value     float64 `json:"value"`
+}
+
+func MakeGlobalFactorsChunks(requests []GlobalFactorRequest) ([][]GlobalFactorRequest, error) {
+	chunkSize := viper.GetInt("api.chunkSize")
+	var chunks [][]GlobalFactorRequest
+
+	for i := 0; i < len(requests); i += chunkSize {
+		end := i + chunkSize
+		if end > len(requests) {
+			end = len(requests)
+		}
+		chunk := requests[i:end]
+		chunks = append(chunks, chunk)
+	}
+	return chunks, nil
+}
+
+func ProcessGlobalFactorsChunks(c *fiber.Ctx, chunks [][]GlobalFactorRequest) error {
+	tx, err := bcdb.DB().BeginTx(c.Context(), nil)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to begin transaction",
+		})
+	}
+	defer tx.Rollback()
+
+	for i, chunk := range chunks {
+		globalFactors := prepareGlobalFactorsData(chunk)
+
+		if err := bulkInsertGlobalFactors(c, tx, globalFactors); err != nil {
+			log.Error().Err(err).Msgf("failed to process global factor bulk update for chunk %d", i)
+			return err
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Error().Err(err).Msg("failed to commit transaction in global factor bulk update")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "failed to commit transaction",
+		})
+	}
+
+	return nil
+}
+
+func prepareGlobalFactorsData(chunk []GlobalFactorRequest) []models.GlobalFactor {
+	var globalFactors []models.GlobalFactor
+
+	for _, data := range chunk {
+		globalFactors = append(globalFactors, models.GlobalFactor{
+			Key:         data.Key,
+			PublisherID: data.Publisher,
+			Value:       null.Float64From(data.Value),
+		})
+	}
+
+	return globalFactors
+}
+
+func bulkInsertGlobalFactors(c *fiber.Ctx, tx *sql.Tx, globalFactors []models.GlobalFactor) error {
+	const excluded = " = EXCLUDED."
+
+	columns := []string{
+		models.GlobalFactorColumns.Key,
+		models.GlobalFactorColumns.PublisherID,
+		models.GlobalFactorColumns.Value,
+		models.GlobalFactorColumns.CreatedAt,
+	}
+	conflictColumns := []string{models.GlobalFactorColumns.Key, models.GlobalFactorColumns.PublisherID}
+	updateColumns := []string{
+		models.GlobalFactorColumns.Value + excluded + models.GlobalFactorColumns.Value,
+		models.GlobalFactorColumns.UpdatedAt + excluded + models.GlobalFactorColumns.CreatedAt,
+	}
+
+	var values []interface{}
+	currTime := time.Now().In(boil.GetLocation())
+	for _, globalFactor := range globalFactors {
+		values = append(values, globalFactor.Key, globalFactor.PublisherID, globalFactor.Value, currTime)
+	}
+
+	return InsertInBulk(c, tx, models.TableNames.GlobalFactor, columns, values, conflictColumns, updateColumns)
+}

--- a/core/global_factor.go
+++ b/core/global_factor.go
@@ -3,6 +3,8 @@ package core
 import (
 	"context"
 	"database/sql"
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/m6yf/bcwork/bcdb"
 	"github.com/m6yf/bcwork/bcdb/filter"
@@ -14,7 +16,6 @@ import (
 	"github.com/volatiletech/null/v8"
 	"github.com/volatiletech/sqlboiler/v4/boil"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
-	"time"
 )
 
 type GetGlobalFactorOptions struct {
@@ -41,7 +42,7 @@ type GlobalFactorRequest struct {
 type GlobalFactor struct {
 	Key         string     `boil:"key" json:"key" toml:"key" yaml:"key"`
 	PublisherID string     `boil:"publisher_id" json:"publisher_id,omitempty" toml:"publisher_id" yaml:"publisher_id"`
-	Value       float64    `boil:"value" json:"value,omitempty" toml:"value" yaml:"value"`
+	Value       float64    `boil:"value" json:"value" toml:"value" yaml:"value"`
 	CreatedById string     `boil:"created_by_id" json:"created_by_id,omitempty" toml:"created_by_id" yaml:"created_by_id"`
 	CreatedAt   *time.Time `boil:"created_at" json:"created_at,omitempty" toml:"created_at" yaml:"created_at"`
 	UpdatedAt   *time.Time `boil:"updated_at" json:"updated_at,omitempty" toml:"updated_at" yaml:"updated_at,omitempty"`

--- a/core/global_factor.go
+++ b/core/global_factor.go
@@ -26,24 +26,21 @@ type GetGlobalFactorOptions struct {
 }
 
 type GlobalFactorFilter struct {
-	Key         filter.StringArrayFilter `json:"key"`
-	Publisher   filter.StringArrayFilter `json:"publisher_id"`
-	Value       filter.StringArrayFilter `json:"value"`
-	CreatedById filter.StringArrayFilter `json:"created_by_id"`
+	Key       filter.StringArrayFilter `json:"key"`
+	Publisher filter.StringArrayFilter `json:"publisher_id"`
+	Value     filter.StringArrayFilter `json:"value"`
 }
 
 type GlobalFactorRequest struct {
-	Key         string  `json:"key" validate:"globalFactorKey"`
-	Publisher   string  `json:"publisher_id" `
-	Value       float64 `json:"value"`
-	CreatedById string  `json:"created_by_id" validate:"required"`
+	Key       string  `json:"key" validate:"globalFactorKey"`
+	Publisher string  `json:"publisher_id" `
+	Value     float64 `json:"value"`
 }
 
 type GlobalFactor struct {
 	Key         string     `boil:"key" json:"key" toml:"key" yaml:"key"`
 	PublisherID string     `boil:"publisher_id" json:"publisher_id,omitempty" toml:"publisher_id" yaml:"publisher_id"`
 	Value       float64    `boil:"value" json:"value" toml:"value" yaml:"value"`
-	CreatedById string     `boil:"created_by_id" json:"created_by_id,omitempty" toml:"created_by_id" yaml:"created_by_id"`
 	CreatedAt   *time.Time `boil:"created_at" json:"created_at,omitempty" toml:"created_at" yaml:"created_at"`
 	UpdatedAt   *time.Time `boil:"updated_at" json:"updated_at,omitempty" toml:"updated_at" yaml:"updated_at,omitempty"`
 }
@@ -91,9 +88,6 @@ func (globalFactor *GlobalFactor) FromModel(mod *models.GlobalFactor) error {
 	globalFactor.UpdatedAt = mod.UpdatedAt.Ptr()
 	globalFactor.Key = mod.Key
 	globalFactor.Value = mod.Value.Float64
-	if mod.CreatedByID.Valid {
-		globalFactor.CreatedById = mod.CreatedByID.String
-	}
 
 	return nil
 }
@@ -104,7 +98,6 @@ func UpdateGlobalFactor(c *fiber.Ctx, data *GlobalFactorRequest) error {
 		Key:         data.Key,
 		PublisherID: data.Publisher,
 		Value:       null.Float64From(data.Value),
-		CreatedByID: null.StringFrom(data.CreatedById),
 	}
 
 	return globalFactor.Upsert(c.Context(), bcdb.DB(), true, []string{models.GlobalFactorColumns.PublisherID, models.GlobalFactorColumns.Key}, boil.Infer(), boil.Infer())
@@ -124,10 +117,6 @@ func (filter *GlobalFactorFilter) QueryMod() qmods.QueryModsSlice {
 
 	if len(filter.Key) > 0 {
 		mods = append(mods, filter.Key.AndIn(models.GlobalFactorColumns.Key))
-	}
-
-	if len(filter.CreatedById) > 0 {
-		mods = append(mods, filter.CreatedById.AndIn(models.GlobalFactorColumns.CreatedByID))
 	}
 
 	if len(filter.Value) > 0 {

--- a/migrations/010_delete_created_by_id_from_global_factor.sql
+++ b/migrations/010_delete_created_by_id_from_global_factor.sql
@@ -1,0 +1,2 @@
+ALTER TABLE global_factor 
+DROP COLUMN created_by_id;

--- a/models/global_factor.go
+++ b/models/global_factor.go
@@ -27,7 +27,6 @@ type GlobalFactor struct {
 	Key         string       `boil:"key" json:"key" toml:"key" yaml:"key"`
 	PublisherID string       `boil:"publisher_id" json:"publisher_id" toml:"publisher_id" yaml:"publisher_id"`
 	Value       null.Float64 `boil:"value" json:"value,omitempty" toml:"value" yaml:"value,omitempty"`
-	CreatedByID null.String  `boil:"created_by_id" json:"created_by_id,omitempty" toml:"created_by_id" yaml:"created_by_id,omitempty"`
 	UpdatedAt   null.Time    `boil:"updated_at" json:"updated_at,omitempty" toml:"updated_at" yaml:"updated_at,omitempty"`
 	CreatedAt   null.Time    `boil:"created_at" json:"created_at,omitempty" toml:"created_at" yaml:"created_at,omitempty"`
 
@@ -39,14 +38,12 @@ var GlobalFactorColumns = struct {
 	Key         string
 	PublisherID string
 	Value       string
-	CreatedByID string
 	UpdatedAt   string
 	CreatedAt   string
 }{
 	Key:         "key",
 	PublisherID: "publisher_id",
 	Value:       "value",
-	CreatedByID: "created_by_id",
 	UpdatedAt:   "updated_at",
 	CreatedAt:   "created_at",
 }
@@ -55,14 +52,12 @@ var GlobalFactorTableColumns = struct {
 	Key         string
 	PublisherID string
 	Value       string
-	CreatedByID string
 	UpdatedAt   string
 	CreatedAt   string
 }{
 	Key:         "global_factor.key",
 	PublisherID: "global_factor.publisher_id",
 	Value:       "global_factor.value",
-	CreatedByID: "global_factor.created_by_id",
 	UpdatedAt:   "global_factor.updated_at",
 	CreatedAt:   "global_factor.created_at",
 }
@@ -111,14 +106,12 @@ var GlobalFactorWhere = struct {
 	Key         whereHelperstring
 	PublisherID whereHelperstring
 	Value       whereHelpernull_Float64
-	CreatedByID whereHelpernull_String
 	UpdatedAt   whereHelpernull_Time
 	CreatedAt   whereHelpernull_Time
 }{
 	Key:         whereHelperstring{field: "\"global_factor\".\"key\""},
 	PublisherID: whereHelperstring{field: "\"global_factor\".\"publisher_id\""},
 	Value:       whereHelpernull_Float64{field: "\"global_factor\".\"value\""},
-	CreatedByID: whereHelpernull_String{field: "\"global_factor\".\"created_by_id\""},
 	UpdatedAt:   whereHelpernull_Time{field: "\"global_factor\".\"updated_at\""},
 	CreatedAt:   whereHelpernull_Time{field: "\"global_factor\".\"created_at\""},
 }
@@ -140,9 +133,9 @@ func (*globalFactorR) NewStruct() *globalFactorR {
 type globalFactorL struct{}
 
 var (
-	globalFactorAllColumns            = []string{"key", "publisher_id", "value", "created_by_id", "updated_at", "created_at"}
+	globalFactorAllColumns            = []string{"key", "publisher_id", "value", "updated_at", "created_at"}
 	globalFactorColumnsWithoutDefault = []string{"key", "publisher_id"}
-	globalFactorColumnsWithDefault    = []string{"value", "created_by_id", "updated_at", "created_at"}
+	globalFactorColumnsWithDefault    = []string{"value", "updated_at", "created_at"}
 	globalFactorPrimaryKeyColumns     = []string{"key", "publisher_id"}
 	globalFactorGeneratedColumns      = []string{}
 )

--- a/models/global_factor_test.go
+++ b/models/global_factor_test.go
@@ -568,7 +568,7 @@ func testGlobalFactorsSelect(t *testing.T) {
 }
 
 var (
-	globalFactorDBTypes = map[string]string{`Key`: `character varying`, `PublisherID`: `character varying`, `Value`: `double precision`, `CreatedByID`: `character varying`, `UpdatedAt`: `timestamp without time zone`, `CreatedAt`: `timestamp without time zone`}
+	globalFactorDBTypes = map[string]string{`Key`: `character varying`, `PublisherID`: `character varying`, `Value`: `double precision`, `UpdatedAt`: `timestamp without time zone`, `CreatedAt`: `timestamp without time zone`}
 	_                   = bytes.MinRead
 )
 

--- a/validations/bulkGlobalFactorsValidation.go
+++ b/validations/bulkGlobalFactorsValidation.go
@@ -1,0 +1,63 @@
+package validations
+
+import (
+	"fmt"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/gofiber/fiber/v2"
+	"github.com/m6yf/bcwork/core"
+)
+
+type errorBulkResponse struct {
+	Status  string              `json:"status"`
+	Message map[string][]string `json:"message"`
+}
+
+const (
+	errorStatus        = "error"
+	keyValidationError = "key most be one of the following: 'tech_fee', 'consultant_fee' or 'tam_fee'"
+)
+
+func ValidateBulkGlobalFactor(c *fiber.Ctx) error {
+	var requests []*core.GlobalFactorRequest
+	err := c.BodyParser(&requests)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"status":  "error",
+			"message": "Invalid request body for Global Factor. Please ensure it's a valid JSON.",
+		})
+	}
+
+	errorResponse := validateBulkGlobalFactor(requests)
+
+	if errorResponse.Status == errorStatus {
+		return c.Status(fiber.StatusBadRequest).JSON(errorResponse)
+	}
+
+	return c.Next()
+}
+
+func validateBulkGlobalFactor(requests []*core.GlobalFactorRequest) errorBulkResponse {
+	var errorMessages = map[string]string{
+		"globalFactorKey": keyValidationError,
+	}
+
+	errorResponse := errorBulkResponse{Message: make(map[string][]string)}
+	for idx, request := range requests {
+		err := Validator.Struct(request)
+		if err != nil {
+			errorResponse.Status = errorStatus
+			key := fmt.Sprintf("request %v", idx+1)
+			for _, err := range err.(validator.ValidationErrors) {
+				if msg, ok := errorMessages[err.Tag()]; ok {
+					errorResponse.Message[key] = append(errorResponse.Message[key], msg)
+				} else {
+					errorResponse.Message[key] = append(errorResponse.Message[key],
+						fmt.Sprintf("%s is mandatory, validation failed", err.Field()))
+				}
+			}
+		}
+	}
+
+	return errorResponse
+}

--- a/validations/bulkGlobalFactorsValidation_test.go
+++ b/validations/bulkGlobalFactorsValidation_test.go
@@ -1,0 +1,76 @@
+package validations
+
+import (
+	"testing"
+
+	"github.com/m6yf/bcwork/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validateBulkGlobalFactor(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		requests []*core.GlobalFactorRequest
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want errorBulkResponse
+	}{
+		{
+			name: "valid",
+			args: args{
+				requests: []*core.GlobalFactorRequest{
+					{
+						Key:       "consultant_fee",
+						Publisher: "publisher_1",
+						Value:     5,
+					},
+					{
+						Key:       "consultant_fee",
+						Publisher: "publisher_2",
+						Value:     10,
+					},
+				},
+			},
+			want: errorBulkResponse{
+				Message: make(map[string][]string),
+			},
+		},
+		{
+			name: "validationError",
+			args: args{
+				requests: []*core.GlobalFactorRequest{
+					{
+						Key:       "consultant_fee",
+						Publisher: "publisher_1",
+						Value:     5,
+					},
+					{
+						Key:       "unknown_fee",
+						Publisher: "publisher_2",
+						Value:     10,
+					},
+				},
+			},
+			want: errorBulkResponse{
+				Status: errorStatus,
+				Message: map[string][]string{
+					"request 2": {keyValidationError},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := validateBulkGlobalFactor(tt.args.requests)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/validations/bulkGlobalFactorsValidation_test.go
+++ b/validations/bulkGlobalFactorsValidation_test.go
@@ -36,7 +36,7 @@ func Test_validateBulkGlobalFactor(t *testing.T) {
 				},
 			},
 			want: errorBulkResponse{
-				Message: make(map[string][]string),
+				Errors: make(map[string][]string),
 			},
 		},
 		{
@@ -56,8 +56,9 @@ func Test_validateBulkGlobalFactor(t *testing.T) {
 				},
 			},
 			want: errorBulkResponse{
-				Status: errorStatus,
-				Message: map[string][]string{
+				Status:  errorStatus,
+				Message: validationError,
+				Errors: map[string][]string{
 					"request 2": {keyValidationError},
 				},
 			},

--- a/validations/globalFactorValidation.go
+++ b/validations/globalFactorValidation.go
@@ -2,6 +2,7 @@ package validations
 
 import (
 	"fmt"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/gofiber/fiber/v2"
 	"github.com/m6yf/bcwork/core"
@@ -18,7 +19,7 @@ func ValidateGlobalFactor(c *fiber.Ctx) error {
 	}
 
 	var errorMessages = map[string]string{
-		"globalFactorKey": fmt.Sprintf("key most be one of the following: 'tech_fee', 'consultant_fee' or 'tam_fee'"),
+		"globalFactorKey": keyValidationError,
 	}
 
 	err = Validator.Struct(body)


### PR DESCRIPTION
1. Created a new endpoint POST /bulk/global/factor to update more than one global factor at the same time;
2. Deleted column "created_by_id" (need to run `migrations/010_delete_created_by_id_from_global_factor.sql`);
3. Global factor get endpoint will return "0" value, if some of the rows will have it;
4. Request validation for new endpoint will return all errors for all request. For example:
Request:
``` json
[
    {
        "key": "unknown_fee",
        "value": 10
    },
    {
        "key": "tech_fee",
        "publisher_id": "2",
        "value": 5
    }
]
```

Response:
``` json
{
    "status": "error",
    "message": "couldn't validate some of the requests",
    "errors": {
        "request 1": [
            "key most be one of the following: 'tech_fee', 'consultant_fee' or 'tam_fee'"
        ],
        "request 2": [
            "only 'consultant_fee' can have publisher"
        ]
    }
}
```