### PR TITLE
3331 Publisher details endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /deploy/ansible/files/bcwork
 config.yaml
 .idea/*
-
+.vscode/
+.DS_Store

--- a/api/rest/docs/docs.go
+++ b/api/rest/docs/docs.go
@@ -199,7 +199,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/bulk.FloorUpdateRequest"
+                                "$ref": "#/definitions/constant.FloorUpdateRequest"
                             }
                         }
                     }
@@ -703,7 +703,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/core.FloorUpdateRequest"
+                            "$ref": "#/definitions/constant.FloorUpdateRequest"
                         }
                     }
                 ],
@@ -1074,6 +1074,42 @@ const docTemplate = `{
                 }
             }
         },
+        "/publisher/details/get": {
+            "post": {
+                "description": "Get Publishers with information about domains and factors setup",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Publisher Domain Factor"
+                ],
+                "parameters": [
+                    {
+                        "description": "options",
+                        "name": "options",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/core.GetPublisherDetailsOptions"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/core.PublisherDetail"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/publisher/domain": {
             "post": {
                 "security": [
@@ -1394,26 +1430,6 @@ const docTemplate = `{
                 }
             }
         },
-        "bulk.FloorUpdateRequest": {
-            "type": "object",
-            "properties": {
-                "country": {
-                    "type": "string"
-                },
-                "device": {
-                    "type": "string"
-                },
-                "domain": {
-                    "type": "string"
-                },
-                "floor": {
-                    "type": "number"
-                },
-                "publisher": {
-                    "type": "string"
-                }
-            }
-        },
         "bulk.FloorUpdateResponse": {
             "type": "object",
             "properties": {
@@ -1440,6 +1456,38 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "constant.FloorUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "browser": {
+                    "type": "string"
+                },
+                "country": {
+                    "type": "string"
+                },
+                "device": {
+                    "type": "string"
+                },
+                "domain": {
+                    "type": "string"
+                },
+                "floor": {
+                    "type": "number"
+                },
+                "os": {
+                    "type": "string"
+                },
+                "placement_type": {
+                    "type": "string"
+                },
+                "publisher": {
+                    "type": "string"
+                },
+                "rule_id": {
                     "type": "string"
                 }
             }
@@ -1869,38 +1917,6 @@ const docTemplate = `{
                 }
             }
         },
-        "core.FloorUpdateRequest": {
-            "type": "object",
-            "properties": {
-                "browser": {
-                    "type": "string"
-                },
-                "country": {
-                    "type": "string"
-                },
-                "device": {
-                    "type": "string"
-                },
-                "domain": {
-                    "type": "string"
-                },
-                "floor": {
-                    "type": "number"
-                },
-                "os": {
-                    "type": "string"
-                },
-                "placement_type": {
-                    "type": "string"
-                },
-                "publisher": {
-                    "type": "string"
-                },
-                "rule_id": {
-                    "type": "string"
-                }
-            }
-        },
         "core.GetConfiantOptions": {
             "type": "object",
             "properties": {
@@ -1986,6 +2002,26 @@ const docTemplate = `{
             "properties": {
                 "filter": {
                     "$ref": "#/definitions/core.PixalateFilter"
+                },
+                "order": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/order.Field"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/pagination.Pagination"
+                },
+                "selector": {
+                    "type": "string"
+                }
+            }
+        },
+        "core.GetPublisherDetailsOptions": {
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "$ref": "#/definitions/core.PublisherDetailsFilter"
                 },
                 "order": {
                     "type": "array",
@@ -2094,7 +2130,8 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "value": {
-                    "type": "number"
+                    "type": "number",
+                    "minimum": 0
                 }
             }
         },
@@ -2264,6 +2301,58 @@ const docTemplate = `{
                 },
                 "status": {
                     "type": "string"
+                }
+            }
+        },
+        "core.PublisherDetail": {
+            "type": "object",
+            "properties": {
+                "account_manager_id": {
+                    "type": "string"
+                },
+                "automation": {
+                    "type": "boolean"
+                },
+                "domain": {
+                    "type": "string"
+                },
+                "gpp_target": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "publisher_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "core.PublisherDetailsFilter": {
+            "type": "object",
+            "properties": {
+                "automation": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "domain": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "gpp_target": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "publisher_id": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/api/rest/docs/docs.go
+++ b/api/rest/docs/docs.go
@@ -1076,7 +1076,7 @@ const docTemplate = `{
         },
         "/publisher/details/get": {
             "post": {
-                "description": "Get Publishers with information about domains and factors setup",
+                "description": "Get Publishers with information about domains setup",
                 "consumes": [
                     "application/json"
                 ],
@@ -1084,7 +1084,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "Publisher Domain Factor"
+                    "publisher"
                 ],
                 "parameters": [
                     {

--- a/api/rest/docs/swagger.json
+++ b/api/rest/docs/swagger.json
@@ -188,7 +188,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/bulk.FloorUpdateRequest"
+                                "$ref": "#/definitions/constant.FloorUpdateRequest"
                             }
                         }
                     }
@@ -692,7 +692,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/core.FloorUpdateRequest"
+                            "$ref": "#/definitions/constant.FloorUpdateRequest"
                         }
                     }
                 ],
@@ -1063,6 +1063,42 @@
                 }
             }
         },
+        "/publisher/details/get": {
+            "post": {
+                "description": "Get Publishers with information about domains and factors setup",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Publisher Domain Factor"
+                ],
+                "parameters": [
+                    {
+                        "description": "options",
+                        "name": "options",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/core.GetPublisherDetailsOptions"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/core.PublisherDetail"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/publisher/domain": {
             "post": {
                 "security": [
@@ -1383,26 +1419,6 @@
                 }
             }
         },
-        "bulk.FloorUpdateRequest": {
-            "type": "object",
-            "properties": {
-                "country": {
-                    "type": "string"
-                },
-                "device": {
-                    "type": "string"
-                },
-                "domain": {
-                    "type": "string"
-                },
-                "floor": {
-                    "type": "number"
-                },
-                "publisher": {
-                    "type": "string"
-                }
-            }
-        },
         "bulk.FloorUpdateResponse": {
             "type": "object",
             "properties": {
@@ -1429,6 +1445,38 @@
             "type": "object",
             "properties": {
                 "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "constant.FloorUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "browser": {
+                    "type": "string"
+                },
+                "country": {
+                    "type": "string"
+                },
+                "device": {
+                    "type": "string"
+                },
+                "domain": {
+                    "type": "string"
+                },
+                "floor": {
+                    "type": "number"
+                },
+                "os": {
+                    "type": "string"
+                },
+                "placement_type": {
+                    "type": "string"
+                },
+                "publisher": {
+                    "type": "string"
+                },
+                "rule_id": {
                     "type": "string"
                 }
             }
@@ -1858,38 +1906,6 @@
                 }
             }
         },
-        "core.FloorUpdateRequest": {
-            "type": "object",
-            "properties": {
-                "browser": {
-                    "type": "string"
-                },
-                "country": {
-                    "type": "string"
-                },
-                "device": {
-                    "type": "string"
-                },
-                "domain": {
-                    "type": "string"
-                },
-                "floor": {
-                    "type": "number"
-                },
-                "os": {
-                    "type": "string"
-                },
-                "placement_type": {
-                    "type": "string"
-                },
-                "publisher": {
-                    "type": "string"
-                },
-                "rule_id": {
-                    "type": "string"
-                }
-            }
-        },
         "core.GetConfiantOptions": {
             "type": "object",
             "properties": {
@@ -1975,6 +1991,26 @@
             "properties": {
                 "filter": {
                     "$ref": "#/definitions/core.PixalateFilter"
+                },
+                "order": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/order.Field"
+                    }
+                },
+                "pagination": {
+                    "$ref": "#/definitions/pagination.Pagination"
+                },
+                "selector": {
+                    "type": "string"
+                }
+            }
+        },
+        "core.GetPublisherDetailsOptions": {
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "$ref": "#/definitions/core.PublisherDetailsFilter"
                 },
                 "order": {
                     "type": "array",
@@ -2083,7 +2119,8 @@
                     "type": "string"
                 },
                 "value": {
-                    "type": "number"
+                    "type": "number",
+                    "minimum": 0
                 }
             }
         },
@@ -2253,6 +2290,58 @@
                 },
                 "status": {
                     "type": "string"
+                }
+            }
+        },
+        "core.PublisherDetail": {
+            "type": "object",
+            "properties": {
+                "account_manager_id": {
+                    "type": "string"
+                },
+                "automation": {
+                    "type": "boolean"
+                },
+                "domain": {
+                    "type": "string"
+                },
+                "gpp_target": {
+                    "type": "number"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "publisher_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "core.PublisherDetailsFilter": {
+            "type": "object",
+            "properties": {
+                "automation": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "domain": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "gpp_target": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "publisher_id": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/api/rest/docs/swagger.json
+++ b/api/rest/docs/swagger.json
@@ -1065,7 +1065,7 @@
         },
         "/publisher/details/get": {
             "post": {
-                "description": "Get Publishers with information about domains and factors setup",
+                "description": "Get Publishers with information about domains setup",
                 "consumes": [
                     "application/json"
                 ],
@@ -1073,7 +1073,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "Publisher Domain Factor"
+                    "publisher"
                 ],
                 "parameters": [
                     {

--- a/api/rest/docs/swagger.yaml
+++ b/api/rest/docs/swagger.yaml
@@ -1553,7 +1553,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: Get Publishers with information about domains and factors setup
+      description: Get Publishers with information about domains setup
       parameters:
       - description: options
         in: body
@@ -1571,7 +1571,7 @@ paths:
               $ref: '#/definitions/core.PublisherDetail'
             type: array
       tags:
-      - Publisher Domain Factor
+      - publisher
   /publisher/domain:
     post:
       consumes:

--- a/api/rest/docs/swagger.yaml
+++ b/api/rest/docs/swagger.yaml
@@ -17,19 +17,6 @@ definitions:
       status:
         type: string
     type: object
-  bulk.FloorUpdateRequest:
-    properties:
-      country:
-        type: string
-      device:
-        type: string
-      domain:
-        type: string
-      floor:
-        type: number
-      publisher:
-        type: string
-    type: object
   bulk.FloorUpdateResponse:
     properties:
       status:
@@ -47,6 +34,27 @@ definitions:
   bulk.GlobalFactorUpdateResponse:
     properties:
       status:
+        type: string
+    type: object
+  constant.FloorUpdateRequest:
+    properties:
+      browser:
+        type: string
+      country:
+        type: string
+      device:
+        type: string
+      domain:
+        type: string
+      floor:
+        type: number
+      os:
+        type: string
+      placement_type:
+        type: string
+      publisher:
+        type: string
+      rule_id:
         type: string
     type: object
   core.Confiant:
@@ -327,27 +335,6 @@ definitions:
           type: string
         type: array
     type: object
-  core.FloorUpdateRequest:
-    properties:
-      browser:
-        type: string
-      country:
-        type: string
-      device:
-        type: string
-      domain:
-        type: string
-      floor:
-        type: number
-      os:
-        type: string
-      placement_type:
-        type: string
-      publisher:
-        type: string
-      rule_id:
-        type: string
-    type: object
   core.GetConfiantOptions:
     properties:
       filter:
@@ -404,6 +391,19 @@ definitions:
     properties:
       filter:
         $ref: '#/definitions/core.PixalateFilter'
+      order:
+        items:
+          $ref: '#/definitions/order.Field'
+        type: array
+      pagination:
+        $ref: '#/definitions/pagination.Pagination'
+      selector:
+        type: string
+    type: object
+  core.GetPublisherDetailsOptions:
+    properties:
+      filter:
+        $ref: '#/definitions/core.PublisherDetailsFilter'
       order:
         items:
           $ref: '#/definitions/order.Field'
@@ -474,6 +474,7 @@ definitions:
       publisher_id:
         type: string
       value:
+        minimum: 0
         type: number
     type: object
   core.Pixalate:
@@ -586,6 +587,40 @@ definitions:
         type: string
       status:
         type: string
+    type: object
+  core.PublisherDetail:
+    properties:
+      account_manager_id:
+        type: string
+      automation:
+        type: boolean
+      domain:
+        type: string
+      gpp_target:
+        type: number
+      name:
+        type: string
+      publisher_id:
+        type: string
+    type: object
+  core.PublisherDetailsFilter:
+    properties:
+      automation:
+        items:
+          type: string
+        type: array
+      domain:
+        items:
+          type: string
+        type: array
+      gpp_target:
+        items:
+          type: string
+        type: array
+      publisher_id:
+        items:
+          type: string
+        type: array
     type: object
   core.PublisherDomain:
     properties:
@@ -966,7 +1001,7 @@ paths:
         required: true
         schema:
           items:
-            $ref: '#/definitions/bulk.FloorUpdateRequest'
+            $ref: '#/definitions/constant.FloorUpdateRequest'
           type: array
       produces:
       - application/json
@@ -1279,7 +1314,7 @@ paths:
         name: options
         required: true
         schema:
-          $ref: '#/definitions/core.FloorUpdateRequest'
+          $ref: '#/definitions/constant.FloorUpdateRequest'
       produces:
       - application/json
       responses:
@@ -1514,6 +1549,29 @@ paths:
       summary: Count publishers
       tags:
       - publisher
+  /publisher/details/get:
+    post:
+      consumes:
+      - application/json
+      description: Get Publishers with information about domains and factors setup
+      parameters:
+      - description: options
+        in: body
+        name: options
+        required: true
+        schema:
+          $ref: '#/definitions/core.GetPublisherDetailsOptions'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/core.PublisherDetail'
+            type: array
+      tags:
+      - Publisher Domain Factor
   /publisher/domain:
     post:
       consumes:

--- a/api/rest/publisher_details.go
+++ b/api/rest/publisher_details.go
@@ -1,0 +1,28 @@
+package rest
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/m6yf/bcwork/core"
+	"github.com/m6yf/bcwork/utils"
+)
+
+// PublisherDetailsGetHandler Get Publisher with information about domains and factors setup
+// @Description Get Publishers with information about domains and factors setup
+// @Tags Publisher Domain Factor
+// @Accept json
+// @Produce json
+// @Param options body core.GetPublisherDetailsOptions true "options"
+// @Success 200 {object} core.PublisherDetailsSlice
+// @Router /publisher/details/get [post]
+func PublisherDetailsGetHandler(c *fiber.Ctx) error {
+	data := &core.GetPublisherDetailsOptions{}
+	if err := c.BodyParser(&data); err != nil {
+		return utils.ErrorResponse(c, fiber.StatusInternalServerError, "Request body for publisher domain parsing error", err)
+	}
+
+	pubs, err := core.GetPublisherDetails(c.Context(), data)
+	if err != nil {
+		return utils.ErrorResponse(c, fiber.StatusBadRequest, "Failed to retrieve publisher domain", err)
+	}
+	return c.JSON(pubs)
+}

--- a/api/rest/publisher_details.go
+++ b/api/rest/publisher_details.go
@@ -6,9 +6,9 @@ import (
 	"github.com/m6yf/bcwork/utils"
 )
 
-// PublisherDetailsGetHandler Get Publisher with information about domains and factors setup
-// @Description Get Publishers with information about domains and factors setup
-// @Tags Publisher Domain Factor
+// PublisherDetailsGetHandler Get Publishers with information about domains setup
+// @Description Get Publishers with information about domains setup
+// @Tags publisher
 // @Accept json
 // @Produce json
 // @Param options body core.GetPublisherDetailsOptions true "options"
@@ -17,12 +17,12 @@ import (
 func PublisherDetailsGetHandler(c *fiber.Ctx) error {
 	data := &core.GetPublisherDetailsOptions{}
 	if err := c.BodyParser(&data); err != nil {
-		return utils.ErrorResponse(c, fiber.StatusInternalServerError, "Request body for publisher domain parsing error", err)
+		return utils.ErrorResponse(c, fiber.StatusInternalServerError, "Request body for publisher details parsing error", err)
 	}
 
 	pubs, err := core.GetPublisherDetails(c.Context(), data)
 	if err != nil {
-		return utils.ErrorResponse(c, fiber.StatusBadRequest, "Failed to retrieve publisher domain", err)
+		return utils.ErrorResponse(c, fiber.StatusBadRequest, "Failed to retrieve publisher details", err)
 	}
 	return c.JSON(pubs)
 }

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -28,7 +28,6 @@ import (
 	"github.com/supertokens/supertokens-golang/supertokens"
 
 	_ "github.com/m6yf/bcwork/api/rest/docs"
-	_ "github.com/m6yf/bcwork/validations"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/volatiletech/sqlboiler/v4/boil"
@@ -232,6 +231,7 @@ func ApiCmd(cmd *cobra.Command, args []string) {
 	app.Post("/publisher/update", rest.PublisherUpdateHandler)
 	app.Post("/publisher/get", rest.PublisherGetHandler)
 	app.Post("/publisher/count", rest.PublisherCountHandler)
+	app.Post("/publisher/details/get", rest.PublisherDetailsGetHandler)
 
 	app.Post("/publisher/domain/get", rest.PublisherDomainGetHandler)
 	app.Post("/publisher/domain", validations.PublisherDomainValidation, rest.PublisherDomainPostHandler)

--- a/core/publisher_details.go
+++ b/core/publisher_details.go
@@ -1,0 +1,113 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/m6yf/bcwork/bcdb"
+	"github.com/m6yf/bcwork/bcdb/filter"
+	"github.com/m6yf/bcwork/bcdb/order"
+	"github.com/m6yf/bcwork/bcdb/pagination"
+	"github.com/m6yf/bcwork/bcdb/qmods"
+	"github.com/m6yf/bcwork/models"
+	"github.com/rotisserie/eris"
+	"github.com/volatiletech/sqlboiler/v4/queries/qm"
+)
+
+type GetPublisherDetailsOptions struct {
+	Filter     PublisherDetailsFilter `json:"filter"`
+	Pagination *pagination.Pagination `json:"pagination"`
+	Order      order.Sort             `json:"order"`
+	Selector   string                 `json:"selector"`
+}
+
+type PublisherDetailsFilter struct {
+	PublisherID filter.StringArrayFilter `json:"publisher_id,omitempty"`
+	Domain      filter.StringArrayFilter `json:"domain,omitempty"`
+	Automation  filter.StringArrayFilter `json:"automation,omitempty"`
+	GppTarget   filter.StringArrayFilter `json:"gpp_target,omitempty"`
+}
+
+func GetPublisherDetails(ctx context.Context, ops *GetPublisherDetailsOptions) (PublisherDetailsSlice, error) {
+	qmods := ops.Filter.QueryMod().
+		Order(ops.Order, nil, models.PublisherColumns.PublisherID).
+		AddArray(ops.Pagination.Do())
+	qmods = qmods.Add(
+		qm.Load(models.PublisherRels.PublisherDomains),
+	)
+
+	var mods models.PublisherSlice
+	mods, err := models.Publishers(qmods...).All(ctx, bcdb.DB())
+	if err != nil && err != sql.ErrNoRows {
+		return nil, eris.Wrap(err, "Failed to retrieve publisher, domains and factor values")
+	}
+
+	res := make(PublisherDetailsSlice, 0, len(mods))
+	res.FromModel(mods)
+
+	return res, nil
+}
+
+func (filter *PublisherDetailsFilter) QueryMod() qmods.QueryModsSlice {
+	const amountOfFields = 6
+
+	mods := make(qmods.QueryModsSlice, 0, amountOfFields)
+	if filter == nil {
+		return mods
+	}
+
+	if len(filter.PublisherID) > 0 {
+		mods = append(mods, filter.PublisherID.AndIn(models.PublisherColumns.PublisherID))
+	}
+
+	if len(filter.Domain) > 0 {
+		mods = append(mods, filter.Domain.AndIn(models.PublisherDomainColumns.Domain))
+	}
+
+	if len(filter.GppTarget) > 0 {
+		mods = append(mods, filter.GppTarget.AndIn(models.PublisherDomainColumns.GPPTarget))
+	}
+
+	if len(filter.Automation) > 0 {
+		mods = append(mods, filter.Automation.AndIn(models.PublisherDomainColumns.Automation))
+	}
+
+	return mods
+}
+
+type PublisherDetail struct {
+	Name             string  `boil:"name" json:"name" toml:"name" yaml:"name"`
+	PublisherID      string  `boil:"publisher_id" json:"publisher_id" toml:"publisher_id" yaml:"publisher_id"`
+	Domain           string  `boil:"domain" json:"domain" toml:"domain" yaml:"domain"`
+	AccountManagerID string  `boil:"account_manager_id" json:"account_manager_id,omitempty" toml:"account_manager_id" yaml:"account_manager_id,omitempty"`
+	Automation       bool    `boil:"automation" json:"automation" toml:"automation" yaml:"automation"`
+	GPPTarget        float64 `boil:"gpp_target" json:"gpp_target" toml:"gpp_target" yaml:"gpp_target,omitempty"`
+}
+
+func (pd *PublisherDetail) FromModel(mod *models.Publisher, domain *models.PublisherDomain) error {
+	pd.Name = mod.Name
+	pd.PublisherID = mod.PublisherID
+	pd.Domain = domain.Domain
+	pd.AccountManagerID = mod.AccountManagerID.String
+	pd.Automation = domain.Automation
+	pd.GPPTarget = domain.GPPTarget.Float64
+
+	return nil
+}
+
+type PublisherDetailsSlice []*PublisherDetail
+
+func (pds *PublisherDetailsSlice) FromModel(mods models.PublisherSlice) error {
+	for _, mod := range mods {
+		for _, domain := range mod.R.GetPublisherDomains() {
+			pd := PublisherDetail{}
+			err := pd.FromModel(mod, domain)
+			if err != nil {
+				return eris.Cause(err)
+			}
+			*pds = append(*pds, &pd)
+		}
+	}
+
+	return nil
+}

--- a/core/publisher_details_test.go
+++ b/core/publisher_details_test.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/m6yf/bcwork/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/volatiletech/null/v8"
+)
+
+func Test_PublisherDetail_FromModel(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		mod    *models.Publisher
+		domain *models.PublisherDomain
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    PublisherDetail
+		wantErr bool
+	}{
+		{
+			name: "valid",
+			args: args{
+				mod: &models.Publisher{
+					Name:             "publisher",
+					PublisherID:      "id",
+					AccountManagerID: null.String{Valid: true, String: "am_id"},
+				},
+				domain: &models.PublisherDomain{
+					Domain:     "domain",
+					Automation: true,
+					GPPTarget:  null.Float64{Valid: true, Float64: 0.1},
+				},
+			},
+			want: PublisherDetail{
+				Name:             "publisher",
+				PublisherID:      "id",
+				AccountManagerID: "am_id",
+				Domain:           "domain",
+				Automation:       true,
+				GPPTarget:        0.1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pd := PublisherDetail{}
+
+			err := pd.FromModel(tt.args.mod, tt.args.domain)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			// object mutates
+			assert.Equal(t, tt.want, pd)
+		})
+	}
+}


### PR DESCRIPTION
[Task](https://dev.azure.com/onlinemediasolutions/HelpDesk/_workitems/edit/3331/)
1. Created new endpoint POST /publisher/details/get which returns information about publishers with their domains. Example:
```
[
    {
        "name": "Finkiel",
        "publisher_id": "1111111",
        "domain": "finkiel.com",
        "account_manager_id": "5dd8d987f9987710068c922e",
        "automation": false,
        "gpp_target": 0
    },
    {
        "name": "Finkiel",
        "publisher_id": "1111111",
        "domain": "menupriceshub.com",
        "account_manager_id": "5dd8d987f9987710068c922e",
        "automation": true,
        "gpp_target": 3
    }
]
```