### PR TITLE
Fix metadata formula

### DIFF
--- a/core/bid_caching_test.go
+++ b/core/bid_caching_test.go
@@ -173,6 +173,19 @@ func TestCreateBidCachingMetadataGeneration(t *testing.T) {
 			expectedJSON: `{"rules": [{"rule": "(p=20814__d=stream-together.org__c=us__os=.*__dt=.*__pt=.*__b=.*)", "bid_caching": 11, "rule_id": "ad18394a-ee20-58c2-bb9b-dd459550a9f7"}]}`,
 		},
 		{
+			name: "Domain with null value",
+			modBC: models.BidCachingSlice{
+				{
+					RuleID:     "",
+					Publisher:  "20814",
+					Country:    null.StringFrom("us"),
+					BidCaching: 11,
+				},
+			},
+			finalRules:   []BidCachingRealtimeRecord{},
+			expectedJSON: `{"rules": [{"rule": "(p=20814__d=.*__c=us__os=.*__dt=.*__pt=.*__b=.*)", "bid_caching": 11, "rule_id": "2374e146-12a5-59cb-ae6f-8994daa8035d"}]}`,
+		},
+		{
 			name: "Same ruleId different input bid_caching",
 			modBC: models.BidCachingSlice{
 				{

--- a/utils/metadata.go
+++ b/utils/metadata.go
@@ -43,6 +43,10 @@ func GetFormulaRegex(country, domain, device, placement_type, os, browser, publi
 		publisher = ".*"
 	}
 
+	if domain == "" {
+		domain = ".*"
+	}
+
 	if country == "all" || country == "" {
 		country = ".*"
 	}


### PR DESCRIPTION
- if we have empty domain we will have following value
```
{
    "rules": [
        {
            "rule": "(p=21038__d=.*__c=.*__os=.*__dt=desktop__pt=.*__b=.*)",
            "rule_id": "9d287a11-a67e-5a35-8d1c-751f8eaf378b",
            "bid_caching": 18
        }
    ]
}
```