### PR TITLE
[3482] updated js targeting rules: added default value for oms

### DIFF
--- a/core/targeting_test.go
+++ b/core/targeting_test.go
@@ -285,7 +285,7 @@ func Test_createTargetingMetaData(t *testing.T) {
 			},
 			want: &models.MetadataQueue{
 				Key:   utils.JSTagMetaDataKeyPrefix + ":publisher_1:1.com",
-				Value: []byte(`[{"rule_id":"rule_1","rule":"p=publisher_1__d=1.com__s=300x200__c=(il|ru|uk|us)__os=(linux|macos|windows)__dt=(desktop|mobile)__pt=placement__b=(chrome|edge|firefox)__key1=value1__key2=value2__key3=value3","price_model":"cpm","value":0.01,"daily_cap":5},{"rule_id":"rule_2","rule":"p=publisher_1__d=1.com__s=400x100__c=(cn|fr)__os=(linux|macos|windows)__dt=(desktop)__pt=rectangle__b=(edge|opera)","price_model":"revshare","value":0,"daily_cap":null}]`),
+				Value: []byte(`[{"rule_id":"rule_1","rule":"p=publisher_1__d=1.com__s=300x200__c=(il|ru|uk|us)__os=(linux|macos|windows)__dt=(desktop|mobile)__pt=placement__b=(chrome|edge|firefox)__key1=value1__key2=value2__key3=value3","price_model":"cpm","value":0.01,"daily_cap":5},{"rule_id":"rule_2","rule":"p=publisher_1__d=1.com__s=400x100__c=(cn|fr)__os=(linux|macos|windows)__dt=(desktop)__pt=rectangle__b=(edge|opera)__oms=.*","price_model":"revshare","value":0,"daily_cap":null}]`),
 			},
 		},
 	}

--- a/dto/targeting.go
+++ b/dto/targeting.go
@@ -32,8 +32,8 @@ const (
 	TargetingMinValueCostModelRevShare = 0
 	TargetingMaxValueCostModelRevShare = 1
 
-	JSTagHeaderTemplate = "<!-- HTML Tag for publisher='{{ .PublisherName }}', domain='{{ .Domain }}', size='{{ .UnitSize }}', {{ if .KV }}{{ range $key, $value := .KV }}{{ $key }}='{{ $value }}', {{ end }}{{ end }}exported='{{ .DateOfExport }}' -->\n"
-	JSTagBodyTemplate   = "<script src=\"https://rt.marphezis.com/js?pid={{ .PublisherID }}&size={{ .UnitSize }}&dom={{ .Domain }}{{ if .KV }}{{ range $key, $value := .KV }}&{{ $key }}={{ $value }}{{ end }}{{ end }}{{ if .AddGDPR }}&gdpr=${GDPR}&gdpr_concent=${GDPR_CONSENT_883}{{ end }}\"></script>"
+	JSTagHeaderTemplate = "<!-- HTML Tag for publisher='{{ .PublisherName }}', domain='{{ .Domain }}', size='{{ .UnitSize }}', {{ if .KV }}{{ range $key, $value := .KV }}{{ if ne $value \".*\" }}{{ $key }}='{{ $value }}', {{ end }}{{ end }}{{ end }}exported='{{ .DateOfExport }}' -->\n"
+	JSTagBodyTemplate   = "<script src=\"https://rt.marphezis.com/js?pid={{ .PublisherID }}&size={{ .UnitSize }}&dom={{ .Domain }}{{ if .KV }}{{ range $key, $value := .KV }}{{ if ne $value \".*\" }}&{{ $key }}={{ $value }}{{ end }}{{ end }}{{ end }}{{ if .AddGDPR }}&gdpr=${GDPR}&gdpr_concent=${GDPR_CONSENT_883}{{ end }}\"></script>"
 )
 
 var (
@@ -195,7 +195,11 @@ func GetTargetingRegExp(mod *models.Targeting) (string, error) {
 		return baseRegExp + "__" + strings.Join(kvRegExp, "__"), nil
 	}
 
-	return baseRegExp, nil
+	// now KV limit to one key named "oms"
+	// if no KV was provided, "oms" will be set to "all"
+	defaultKV := "__oms=.*"
+
+	return baseRegExp + defaultKV, nil
 }
 
 func GetTargetingKey(publisher, domain string) string {

--- a/dto/targeting_test.go
+++ b/dto/targeting_test.go
@@ -67,9 +67,33 @@ func Test_GetTargetingRegExp(t *testing.T) {
 				DeviceType:    []string{"mobile", "desktop"},
 				Browser:       []string{"chrome", "firefox", "edge"},
 				Os:            []string{"windows", "macos", "linux"},
+			},
+			want: "p=1__d=1.com__s=300x200__c=(ru|uk|us|il)__os=(windows|macos|linux)__dt=(mobile|desktop)__pt=placement__b=(chrome|firefox|edge)__oms=.*",
+		},
+		{
+			name: "valid_WithKV",
+			targeting: &models.Targeting{
+				PublisherID:   "1",
+				Domain:        "1.com",
+				UnitSize:      "300x200",
+				PlacementType: null.StringFrom("placement"),
+				Country:       []string{"ru", "uk", "us", "il"},
+				DeviceType:    []string{"mobile", "desktop"},
+				Browser:       []string{"chrome", "firefox", "edge"},
+				Os:            []string{"windows", "macos", "linux"},
 				KV:            null.JSONFrom([]byte(`{"key1": "value1", "key2": "value2", "key3": "value3"}`)),
 			},
 			want: "p=1__d=1.com__s=300x200__c=(ru|uk|us|il)__os=(windows|macos|linux)__dt=(mobile|desktop)__pt=placement__b=(chrome|firefox|edge)__key1=value1__key2=value2__key3=value3",
+		},
+		{
+			name: "valid_MostGeneric",
+			targeting: &models.Targeting{
+				PublisherID:   "",
+				Domain:        "",
+				UnitSize:      "",
+				PlacementType: null.StringFrom(""),
+			},
+			want: "p=.*__d=.*__s=.*__c=.*__os=.*__dt=.*__pt=.*__b=.*__oms=.*",
 		},
 	}
 
@@ -190,6 +214,32 @@ func Test_GetJSTagString(t *testing.T) {
 			},
 			want: "<!-- HTML Tag for publisher='', domain='1.com', size='300x250', key_1='value_1', key_2='value_2', exported='" + now + "' -->\n" +
 				"<script src=\"https://rt.marphezis.com/js?pid=1&size=300x250&dom=1.com&key_1=value_1&key_2=value_2&gdpr=${GDPR}&gdpr_concent=${GDPR_CONSENT_883}\"></script>",
+		},
+		{
+			name: "valid_WithKVEqualAll",
+			args: args{
+				mod: &models.Targeting{
+					PublisherID: "1",
+					Domain:      "1.com",
+					UnitSize:    "300x250",
+					KV:          null.JSONFrom([]byte(`{"oms":".*"}`)),
+				},
+			},
+			want: "<!-- HTML Tag for publisher='', domain='1.com', size='300x250', exported='" + now + "' -->\n" +
+				"<script src=\"https://rt.marphezis.com/js?pid=1&size=300x250&dom=1.com\"></script>",
+		},
+		{
+			name: "valid_WithOneOfKVEqualAll",
+			args: args{
+				mod: &models.Targeting{
+					PublisherID: "1",
+					Domain:      "1.com",
+					UnitSize:    "300x250",
+					KV:          null.JSONFrom([]byte(`{"oms":".*","key_1":"value_1"}`)),
+				},
+			},
+			want: "<!-- HTML Tag for publisher='', domain='1.com', size='300x250', key_1='value_1', exported='" + now + "' -->\n" +
+				"<script src=\"https://rt.marphezis.com/js?pid=1&size=300x250&dom=1.com&key_1=value_1\"></script>",
 		},
 	}
 


### PR DESCRIPTION
1. added default value (`.*`) for `"oms"` key in KV;
2. if `"oms"` value is `.*`, it will not appear in js tag;

Example of rules:
``` json
[
    {
        "rule": "p=20891__d=test.com__s=120x600__c=.*__os=.*__dt=(mobile)__pt=.*__b=.*__oms=value",
        "value": 0.05,
        "rule_id": "7ce75099-8a6e-558a-b330-6eb6c43ebbea",
        "daily_cap": null,
        "price_model": "cpm"
    },
    {
        "rule": "p=20891__d=test.com__s=320x100__c=(us)__os=.*__dt=(desktop)__pt=.*__b=.*__oms=.*",
        "value": 0.04,
        "rule_id": "b1f36f39-2ceb-5f72-b0e2-1e8b61702552",
        "daily_cap": null,
        "price_model": "revshare"
    }
]
```

Example of tags:
```
<!-- HTML Tag for publisher='Test_Dev_Dates', domain='test.com', size='120x600', oms='value', exported='2025-01-06' --> <script src="https://rt.marphezis.com/js?pid=20891&size=120x600&dom=test.com&_oms=value"></script>
```
```
<!-- HTML Tag for publisher='Test_Dev_Dates', domain='test.com', size='320x100', exported='2025-01-06' --> <script src="https://rt.marphezis.com/js?pid=20891&size=320x100&dom=test.com"></script>
```
